### PR TITLE
Use jpackage for distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.zip
 /id_rsa
 *.log
+/bin
+*.msi

--- a/CayoPericoHeistAssistant/CayoPericoHeistAssistant.bat
+++ b/CayoPericoHeistAssistant/CayoPericoHeistAssistant.bat
@@ -1,1 +1,0 @@
-javaw -jar CayoPericoHeistAssistant.jar

--- a/CayoPericoHeistAssistant/Changelog.txt
+++ b/CayoPericoHeistAssistant/Changelog.txt
@@ -2,6 +2,7 @@
 
 WORK STILL IN PROGRESS
 
+* Switch to jpackage distribution
 * Allow to change difficulty level
 * Change zoom view of Compound, Fix loot location on this view
 * Add zoom view for airstrip, north dock, main dock, fields

--- a/Readme.md
+++ b/Readme.md
@@ -6,22 +6,18 @@ Take a loot at [CayoPericoAssistant/README.txt](CayoPericoAssistant/README.txt) 
 
 **Requirements**
 
-* Java Development Kit >= 11
+* Java Development Kit >= 11 + [backported jpackage](https://mail.openjdk.java.net/pipermail/openjfx-dev/2018-September/022500.html) or JDK >= 14
 * Maven 3
+* Wix Toolkit
 
 **Build**
 
 ```
 mvn package
-cp target\CayoPericoHeistAssistant.jar CayoPericoHeistAssistant
 ```
 
 **Run**
 
-```
-cd CayoPericoHeistAssistant
-CayoPericoHeistAssistant.bat
-```
-
-Run GTA and Go Online first.
-To run, you must have "javaw.exe" directory in your PATH variable.
+Use CayoPericoHeistAssistant.msi to install.  
+Run GTA and Go Online first.  
+Start it from the start menu or destkop shortcut.

--- a/jpackage.bat
+++ b/jpackage.bat
@@ -1,0 +1,2 @@
+copy target\CayoPericoHeistAssistant.jar CayoPericoHeistAssistant\
+jpackage.exe --input CayoPericoHeistAssistant\ --app-version 0.10 --name CayoPericoHeistAssistant --main-jar CayoPericoHeistAssistant.jar --type msi --win-menu --win-shortcut --win-dir-chooser --win-per-user-install

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,23 @@
 				</configuration>
 			</execution>
 		</executions>
-	</plugin>
+  </plugin>
+  <plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>exec-maven-plugin</artifactId>
+    <version>1.5.0</version>
+    <executions>
+      <execution>
+        <phase>package</phase>
+        <goals>
+           <goal>exec</goal>
+        </goals>
+        <configuration>
+          <executable>jpackage.bat</executable>
+        </configuration>
+      </execution>
+    </executions>
+  </plugin>
     </plugins>
   </build>
   


### PR DESCRIPTION
After Java SE 8, Oracle doesn't provide the jre for consumers. They now expect java developers who ship programs to consumers to package a jre with their program. They didn't add the tools for this to the JDK until java 14, which is why projects like yours have been instructing clients to install 3rd party builds of the open source JRE, like adoptopenjdk. I propose that you instead update your jdk to at least 14, or install the backported `jpackage` from [the dev mailing list](https://mail.openjdk.java.net/pipermail/openjfx-dev/2018-September/022500.html), and then merge this request in order to prevent end users having to take additional steps to use your software. `jpackage` on windows also requires the wix toolset.