### PR TITLE
misc additions to #2

### DIFF
--- a/CayoPericoHeistAssistant/CayoPericoHeistAssistant.bat
+++ b/CayoPericoHeistAssistant/CayoPericoHeistAssistant.bat
@@ -1,0 +1,1 @@
+javaw -jar CayoPericoHeistAssistant.jar

--- a/CayoPericoHeistAssistant/README.txt
+++ b/CayoPericoHeistAssistant/README.txt
@@ -72,6 +72,6 @@ WARNING __________________________________________________
 ## Thanks ###########################
 
  - polivias
- - Joseph Mendoza
+ - josephsmendoza
  - unknowncheats Community
 

--- a/jpackage.bat
+++ b/jpackage.bat
@@ -1,2 +1,4 @@
-copy target\CayoPericoHeistAssistant.jar CayoPericoHeistAssistant\
-jpackage.exe --input CayoPericoHeistAssistant\ --app-version 0.10 --name CayoPericoHeistAssistant --main-jar CayoPericoHeistAssistant.jar --type msi --win-menu --win-shortcut --win-dir-chooser --win-per-user-install
+copy target\CayoPericoHeistAssistant.jar CayoPericoHeistAssistant
+rmdir /q /s target\minijre
+jlink --compress 1 --output target\minijre --strip-debug --no-header-files --no-man-pages --strip-native-commands --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.logging,java.management,java.naming,java.rmi,java.scripting,java.sql,java.xml
+jpackage.exe --app-version 0.10 --runtime-image target\minijre --dest target --input CayoPericoHeistAssistant --name CayoPericoHeistAssistant --main-jar CayoPericoHeistAssistant.jar --type msi --win-menu --win-shortcut --win-dir-chooser --win-per-user-install


### PR DESCRIPTION
You make good points about untrusted installers and file size. In #2 I deleted the .bat file from the distro folder thinking it wouldn't be needed, but it should be restored for the zip distro. I also added a step to the jpackage script to generate a mini jre for the installer, on my system this reduced the installer size from ~50mb to ~30mb. Still much larger than a standalone jar, but hopefully helps with size concerns. I ran `jdeps -s target\CayoPericoHeistAssistant.jar` to get the modules list that I put into the `jlink` args, it may be necessary to update that module list in the future as jre components become used/unused.